### PR TITLE
Enable coverage reporting in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,6 @@ jobs:
         run: ./gradlew :iterableapi:jacocoTestDebugUnitTestReport :app:jacocoDebugTestReport  
         run: ./gradlew :iterableapi:testDebugUnitTest :app:testDebugUnitTest
 
-      Coverage reporting temporarily disabled
       - name: Upload coverage data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
@@ -81,7 +80,6 @@ jobs:
           api-level: 28
           script: ./gradlew :iterableapi:connectedCheck
 
- #     Coverage reporting temporarily disabled
       - name: Upload coverage data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,17 +46,17 @@ jobs:
       - run: touch local.properties
 
       - name: Test
-      # run: ./gradlew :iterableapi:jacocoTestDebugUnitTestReport :app:jacocoDebugTestReport  
+        run: ./gradlew :iterableapi:jacocoTestDebugUnitTestReport :app:jacocoDebugTestReport  
         run: ./gradlew :iterableapi:testDebugUnitTest :app:testDebugUnitTest
 
-      # Coverage reporting temporarily disabled
-      # - name: Upload coverage data
-      #   uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-      #   with:
-      #     name: unit-tests
-      #     path: |
-      #       ./**/build/**/jacoco*.xml
-      #       ./**/build/**/report.xml
+      Coverage reporting temporarily disabled
+      - name: Upload coverage data
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: unit-tests
+          path: |
+            ./**/build/**/jacoco*.xml
+            ./**/build/**/report.xml
 
   instrumentation-tests:
     name: Instrumentation tests
@@ -81,52 +81,47 @@ jobs:
           api-level: 28
           script: ./gradlew :iterableapi:connectedCheck
 
-      # Coverage reporting temporarily disabled
-      # - name: Upload coverage data
-      #   uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
-      #   with:
-      #     name: instrumentation-tests
-      #     path: |
-      #       ./**/build/**/jacoco*.xml
-      #       ./**/build/**/report.xml
+ #     Coverage reporting temporarily disabled
+      - name: Upload coverage data
+        uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        with:
+          name: instrumentation-tests
+          path: |
+            ./**/build/**/jacoco*.xml
+            ./**/build/**/report.xml
 
-  # Coverage reporting temporarily disabled
-  # report-coverage:
-  #   name: Report coverage
-  #   runs-on: ubuntu-latest
-  #   needs: [unit-tests, instrumentation-tests]
-  #   env:
-  #     JACOCO_SOURCE_PATH: "iterableapi/src/main/java iterableapi-ui/src/main/java"
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-  #       with:
-  #         fetch-depth: 0
-  #
-  #     - name: Configure JDK
-  #       uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
-  #       with:
-  #         java-version: 17
-  #
-  #     - run: curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-  #     - run: chmod +x ./cc-test-reporter
-  #     - run: ./cc-test-reporter before-build
-  #
-  #     - name: Download unit tests coverage
-  #       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-  #       with:
-  #         name: unit-tests
-  #
-  #     - name: Download instrumentation tests coverage
-  #       uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
-  #       with:
-  #         name: instrumentation-tests
-  #
-  #     - run: bash <(curl -s https://codecov.io/bash)
-  #     - run: ./cc-test-reporter format-coverage app/build/reports/jacoco/jacocoDebugTestReport/jacocoDebugTestReport.xml --input-type jacoco -d
-  #     - run: ./cc-test-reporter format-coverage iterableapi/build/reports/coverage/androidTest/debug/connected/report.xml --input-type jacoco -d
-  #     - run: ./cc-test-reporter format-coverage iterableapi/build/jacoco/jacoco.xml --input-type jacoco -d
-  #     - run: ./cc-test-reporter format-coverage app/build/reports/jacoco/jacocoDebugAndroidTestReport/jacocoDebugAndroidTestReport.xml --input-type jacoco -d
-  #     - run: ./cc-test-reporter upload-coverage
-  #       env:
-  #         CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
+
+  report-coverage:
+    name: Report coverage
+    runs-on: ubuntu-latest
+    needs: [unit-tests, instrumentation-tests]
+    env:
+      JACOCO_SOURCE_PATH: "iterableapi/src/main/java iterableapi-ui/src/main/java"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          fetch-depth: 0
+  
+      - name: Configure JDK
+        uses: actions/setup-java@d202f5dbf7256730fb690ec59f6381650114feb2 # v1.4.3
+        with:
+          java-version: 17
+  
+      - name: Download unit tests coverage
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: unit-tests
+  
+      - name: Download instrumentation tests coverage
+        uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+        with:
+          name: instrumentation-tests
+
+      - name: publish coverage to Qlty
+        uses: qltysh/qlty-action/coverage@v2
+        with:
+          token: ${{ secrets.QLTY_COVERAGE_TOKEN }}
+          files: coverage/*.xml
+
+


### PR DESCRIPTION
Updated the build workflow to enable coverage reporting and added steps to publish coverage data to Qlty.

## 🔹 Jira Ticket(s) if any

* [MOB-XXXX](https://iterable.atlassian.net/browse/MOB-XXXX)

## ✏️ Description

> Please provide a brief description of what this pull request does.
